### PR TITLE
Fixed bug in QVector::Reset()

### DIFF
--- a/src/base/QVector.hpp
+++ b/src/base/QVector.hpp
@@ -156,6 +156,7 @@ class QVector {
     n_ = 0;
     sum_weights_ = 0.;
     quality_ = false;
+    for (auto &q : q_) { q = QVec(); }
   }
 
   /**


### PR DESCRIPTION
Added missing reset of Q Vector x and y components.