### PR TITLE
no abs path in dictionary

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_command(OUTPUT G__${PROJECT_NAME}.cxx
         -rmf lib${PROJECT_NAME}.rootmap
         -s lib${PROJECT_NAME}
         -I${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/${HEADERS}
+        ${HEADERS}
         ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}LinkDef.h
         )
 add_library(${PROJECT_NAME} SHARED ${SOURCES} G__${PROJECT_NAME}.cxx)


### PR DESCRIPTION
Dictionary file G__QnToolsBase.cxx contains absolute path of the first header and the names of all the other headers.
G__QnToolsCorrection.cxx for example does not have this problem. That is why I corrected base/CmakeLists.txt and made it similar to correction/CmakeLists.txt