### PR TITLE
Added a Define QVectorAction to the dataframe methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
 endif (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
 
 # ROOT
-find_package(ROOT REQUIRED COMPONENTS Core MathCore MathMore RIO Hist Tree Net TreePlayer)
+find_package(ROOT REQUIRED COMPONENTS Core MathCore MathMore RIO Hist Tree Net TreePlayer ROOTVecOps)
 include(${ROOT_USE_FILE})
 message(STATUS "Using ROOT: ${ROOT_VERSION} <${ROOT_CONFIG}>")
 set(ROOTCLING ${ROOT_BINDIR}/rootcling)

--- a/src/base/ReSamples.hpp
+++ b/src/base/ReSamples.hpp
@@ -85,7 +85,7 @@ class ReSamples {
   template<typename SAMPLES>
   void Fill(const double value, const double weight, SAMPLES &&sample_multiplicities_) {
     using ArrayValueType = typename std::decay<decltype(std::declval<SAMPLES &>()[0])>::type;
-    for (std::size_t i = 0; i < sample_multiplicities_.size(); ++i) {
+    for (std::size_t i = 0; i < statistics_.size(); ++i) {
       for (ArrayValueType j = 0; j < sample_multiplicities_[i]; ++j) {
         statistics_[i].Fill(value, weight);
       }

--- a/src/dataframe/CMakeLists.txt
+++ b/src/dataframe/CMakeLists.txt
@@ -7,6 +7,7 @@ set(dataframe_headers common/AverageHelper.hpp
         common/EqualBinningHelper.hpp
         common/TemplateHelpers.hpp
         correction/RecenterAction.hpp
+        correction/DefineQAction.hpp
         correlation/CorrelationAction.hpp
         correlation/CorrelationAction.hpp
         correlation/ReSampleHelper.hpp)
@@ -28,8 +29,14 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY EXPORT_NAME DataFrame)
 
 # link to the gtest library if test are enabled
 IF (CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND SOURCES correction/RecenterAction.test.cpp)
+    list(APPEND SOURCES
+            common/AverageHelper.test.cpp
+            common/AxesConfiguration.test.cpp
+            common/QVectorHelper.test.cpp
+            correction/RecenterAction.test.cpp
+            correlation/CorrelationAction.test.cpp
+            )
     add_executable(${PROJECT_NAME}UnitTests ${SOURCES})
-    target_link_libraries(${PROJECT_NAME}UnitTests PRIVATE gtest_main PUBLIC ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}UnitTests PRIVATE ${ROOT_LIBRARIES} gtest_main ${PROJECT_NAME})
     gtest_add_tests(TARGET ${PROJECT_NAME}UnitTests)
 ENDIF (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/src/dataframe/common/AverageHelper.test.cpp
+++ b/src/dataframe/common/AverageHelper.test.cpp
@@ -1,0 +1,52 @@
+// Flow Vector Correction Framework
+//
+// Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
+// Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
+// For a full list of contributors please see docs/Credits
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtest/gtest.h>
+
+#include "AverageHelper.hpp"
+#include "AxesConfiguration.hpp"
+#include "QVectorHelper.hpp"
+#include "RecenterAction.hpp"
+
+/**
+ * Testing if exceptions are thrown in case of double initialization.
+ */
+TEST(AverageHelper, OnlyOneInitialization) {
+  Qn::DataContainerQVector qvec_proto;
+  auto event_axis = Qn::AxisD("event", 1, 0, 2);
+  auto axes = Qn::MakeAxes(event_axis);
+  auto res = Qn::Correction::MakeRecenterAction("test", axes, "q");
+  TTreeReader reader;
+  try {
+    auto rec = Qn::AverageHelper(res)
+                   .SetInitializationWithInitializationObject(&qvec_proto)
+                   .SetInitializationWithExternalTTreeReader(&reader);
+  } catch (std::runtime_error &e) {
+    EXPECT_EQ(e.what(),
+              std::string("Error! SetInitializationWithInitializationObject "
+                          "has already been called."));
+  }
+  try {
+    auto rec = Qn::AverageHelper(res)
+                   .SetInitializationWithExternalTTreeReader(&reader)
+                   .SetInitializationWithInitializationObject(&qvec_proto);
+  } catch (std::runtime_error &e) {
+    EXPECT_EQ(e.what(),
+              std::string("Error! SetInitializationWithExternalTTreeReader has "
+                          "already been called."));
+  }
+}

--- a/src/dataframe/common/AxesConfiguration.test.cpp
+++ b/src/dataframe/common/AxesConfiguration.test.cpp
@@ -1,4 +1,4 @@
-// Qn Tools
+// Flow Vector Correction Framework
 //
 // Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
 // Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
@@ -14,17 +14,16 @@
 // GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#ifndef QNTOOLS_QNDATAFRAME_H_
-#define QNTOOLS_QNDATAFRAME_H_
-// common headers
-#include "AverageHelper.hpp"
+
+#include <gtest/gtest.h>
+
 #include "AxesConfiguration.hpp"
-#include "EqualBinningHelper.hpp"
-#include "QVectorHelper.hpp"
-// correction step
-#include "RecenterAction.hpp"
-// correlation step
-#include "CorrelationAction.hpp"
-#include "CorrelationFunctions.hpp"
-#include "ReSampleHelper.hpp"
-#endif  // QNTOOLS_QNDATAFRAME_H_
+#include "Axis.hpp"
+
+TEST(AxesConfiguration, GetLowerBinEdges) {
+  auto axes =
+      Qn::MakeAxes(Qn::AxisD("test1", 2, 0, 2), Qn::AxisD("test2", 2, 0, 2));
+  auto nbins = axes.GetBinEdgesIndexMap();
+  auto low = nbins[0].first;
+  auto high = nbins[0].first;
+}

--- a/src/dataframe/common/QVectorHelper.hpp
+++ b/src/dataframe/common/QVectorHelper.hpp
@@ -1,0 +1,150 @@
+// Flow Vector Correction Framework
+//
+// Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
+// Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
+// For a full list of contributors please see docs/Credits
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef QNTOOLS_QVECTORACTION_HPP_
+#define QNTOOLS_QVECTORACTION_HPP_
+
+#include <string>
+#include <string_view>
+#include <tuple>
+
+#include <ROOT/RVec.hxx>
+
+#include "AxesConfiguration.hpp"
+#include "Axis.hpp"
+#include "DataContainer.hpp"
+
+namespace Qn {
+/**
+ * predeclaration of DefineQAction class. Used to make variadic templates from a
+ * passed tuple.
+ * @tparam AxesConfig
+ * @tparam EventParameters
+ */
+template <typename AxesConfig, typename DetectorParameters>
+class QVectorHelper;
+
+/**
+ * Defines a Q vector with a variable number of harmonics from a vector of
+ * azimuthal angles and a vector of weights Subevents can be defined with an
+ * AxesConfiguration. For Integrated Q vectors
+ * @tparam AxesConfig
+ * @tparam DetectorParameters
+ */
+template <typename AxesConfig, typename... DetectorParameters>
+class QVectorHelper<AxesConfig, std::tuple<DetectorParameters...>> {
+ public:
+  using AxisValueType = typename AxesConfig::AxisValueType;
+  using AxisValueTypeTuple = typename AxesConfig::AxisValueTypeTuple;
+  using BinEdgesMapping =
+      typename std::vector<std::pair<AxisValueTypeTuple, AxisValueTypeTuple>>;
+  static constexpr std::size_t NumberOfParameters =
+      sizeof...(DetectorParameters);
+  QVectorHelper(std::string_view name, const std::vector<int> &harmonics,
+                AxesConfig axes_config)
+      : name_(name), axes_(axes_config), q_vector_(axes_config.GetVector()) {
+    bin_edges_mapping_ = axes_.GetBinEdgesIndexMap();
+    for (auto &q : q_vector_) {
+      for (auto &harmonic : harmonics) {
+        q.ActivateHarmonic(harmonic);
+      }
+      q.InitializeHarmonics();
+    }
+  }
+  /**
+   * Returns the name of the output Q-vector.
+   * @return name of the output Q-vector
+   */
+  [[nodiscard]] std::string GetName() const { return name_; }
+
+  Qn::DataContainerQVector operator()(const ROOT::RVec<double> &phis,
+                                      const ROOT::RVec<double> &weights,
+                                      DetectorParameters... parameters) {
+    Qn::DataContainerQVector ret = q_vector_;
+    auto rest_phis = phis;
+    auto rest_weights = weights;
+    auto rest_parameters_tuple = std::tuple(parameters...);
+    for (int ibin = 0; ibin < axes_.GetSize(); ++ibin) {
+      auto [lower_edges, upper_edges] = bin_edges_mapping_[ibin];
+      Qn::TemplateHelpers::TupleOf<NumberOfParameters, ROOT::RVec<double>>
+          selections_tuple;
+      auto selector = [](auto &res, auto lower, auto upper, auto value) {
+        res = value >= lower && value < upper;
+      };
+      Qn::TemplateHelpers::TupleForEach(selector, selections_tuple, lower_edges,
+                                        upper_edges, rest_parameters_tuple);
+      auto is_selected = std::apply([&](auto... cond) { return (cond && ...); },
+                                    selections_tuple);
+      auto selected_phis = rest_phis[is_selected];
+      auto selected_weights = rest_weights[is_selected];
+      auto &bin = ret.At(ibin);
+      for (int i = 0; i < selected_phis.size(); ++i) {
+        bin.Add(selected_phis[i], selected_weights[i]);
+      }
+      bin.CheckQuality();
+      rest_phis = rest_phis[!is_selected];
+      rest_weights = rest_weights[!is_selected];
+      rest_parameters_tuple = std::apply(
+          [&is_selected](auto... t) { return std::tuple(t[!is_selected]...); },
+          rest_parameters_tuple);
+    }
+    return ret;
+  }
+
+ private:
+  std::string name_;
+  AxesConfig axes_;
+  BinEdgesMapping bin_edges_mapping_;
+  Qn::DataContainerQVector q_vector_;
+};
+
+/**
+ * Template specialization for integrated Q-Vectors.
+ * AxesConfiguration<AxisD> is a dummy type and will not be used in the
+ * calculation The empty tuple will be ignored.
+ */
+template <>
+inline Qn::DataContainerQVector
+QVectorHelper<AxesConfiguration<AxisD>, typename std::tuple<>>::operator()(
+    const ROOT::RVec<double> &phis, const ROOT::RVec<double> &weights) {
+  Qn::DataContainerQVector ret = q_vector_;
+  auto &outputbin = ret.At(0);
+  for (int i = 0; i < phis.size(); ++i) {
+    outputbin.Add(phis[i], weights[i]);
+  }
+  outputbin.CheckQuality();
+  return ret;
+}
+
+template <typename ParameterAxes>
+auto MakeQVectorHelper(std::string_view name, const std::vector<int> &harmonics,
+                       ParameterAxes axes_config) {
+  using Parameters = typename Qn::TemplateHelpers::TupleOf<
+      ParameterAxes::kDimension,
+      ROOT::RVec<typename ParameterAxes::AxisValueType>>;
+  return QVectorHelper<ParameterAxes, Parameters>(name, harmonics, axes_config);
+}
+
+inline auto MakeQVectorHelper(std::string_view name,
+                              const std::vector<int> &harmonics) {
+  auto axes_null = MakeAxes(AxisD("integrated", 1, 0, 1));
+  return QVectorHelper<decltype(axes_null), std::tuple<>>(name, harmonics,
+                                                          axes_null);
+}
+}  // namespace Qn
+
+#endif  // QNTOOLS_QVECTORACTION_HPP+

--- a/src/dataframe/common/QVectorHelper.test.cpp
+++ b/src/dataframe/common/QVectorHelper.test.cpp
@@ -1,0 +1,213 @@
+// Flow Vector Correction Framework
+//
+// Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
+// Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
+// For a full list of contributors please see docs/Credits
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <iostream>
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RVec.hxx>
+#include <gtest/gtest.h>
+
+#include "AxesConfiguration.hpp"
+#include "QVectorHelper.hpp"
+
+/**
+ * Check the the constructor and the definition of a Q-vector with 1 subevents.
+ * input 4 phi angles (45 deg, 135 deg, 215 deg, 305 deg)
+ *       4 weights (1, 1, 1, 1)
+ *       4 etas    (25, 25, 75, 75)
+ *       subevents are binned in eta with the bin edges (0, 50, 100)
+ *       expectation of the first harmonic Q-vector in the only subevent:
+ *       x_1^{ev_1} = 0, y_1^{ev_1} = 0
+ *
+ */
+TEST(QVectorAction, BasicIntegrated) {
+  auto q_action = Qn::MakeQVectorHelper("test", {1, 2, 3, 4});
+  int si = 4;
+  ROOT::RVec<double> phis(si);
+  ROOT::RVec<double> weights(si);
+  ROOT::RVec<double> etas(si);
+  double angle = 1.;
+  for (int i = 0.; i < si; ++i) {
+    phis[i] = angle / 8 * 2 * TMath::Pi();
+    weights[i] = (double)1;
+    if (i < 2)
+      etas[i] = (double)25.;
+    else
+      etas[i] = (double)75.;
+    angle = angle + 2.;
+  }
+  auto q = q_action(phis, weights);
+  EXPECT_NEAR(q.At(0).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(0).y(1), 0., 1e-5);
+}
+
+/**
+ * Check the the constructor and the definition of a Q-vector with 2 subevents.
+ * input 4 phi angles (45 deg, 135 deg, 215 deg, 305 deg)
+ *       4 weights (1, 1, 1, 1)
+ *       4 etas    (25, 25, 75, 75)
+ *       subevents are binned in eta with the bin edges (0, 50, 100)
+ *       expectation of the first harmonic Q-vector in the first subevent:
+ *       x_1^{ev_1} = 0, y_1^{ev_1} = sqrt(2)
+ *       expectation of the the first harmonic Q-vector in the second subevent:
+ *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
+ *
+ */
+TEST(QVectorAction, Basic1D) {
+  auto axes = Qn::MakeAxes(Qn::AxisD("t1", 2, 0, 100));
+  Qn::QVectorHelper<decltype(axes), std::tuple<ROOT::RVec<double>>> q_action(
+      "test", {1, 2, 3, 4}, axes);
+  int si = 4;
+  ROOT::RVec<double> phis(si);
+  ROOT::RVec<double> weights(si);
+  ROOT::RVec<double> etas(si);
+  double angle = 1.;
+  for (int i = 0.; i < si; ++i) {
+    phis[i] = angle / 8 * 2 * TMath::Pi();
+    weights[i] = (double)1;
+    if (i < 2)
+      etas[i] = (double)25.;
+    else
+      etas[i] = (double)75.;
+    angle = angle + 2.;
+  }
+  auto q = q_action(phis, weights, etas);
+  EXPECT_NEAR(q.At(0).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(0).y(1), std::sqrt(2), 1e-5);
+  EXPECT_NEAR(q.At(1).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(1).y(1), -std::sqrt(2), 1e-5);
+}
+
+/**
+ * Check the the constructor and the definition of a Q-vector with 2 subevents.
+ * input 4 phi angles (45 deg, 135 deg, 215 deg, 305 deg)
+ *       4 weights (1, 1, 1, 1)
+ *       4 etas    (25, 25, 75, 75)
+ *       subevents are binned in eta with the bin edges (0, 50, 100)
+ *       expectation of the first harmonic Q-vector in the first subevent:
+ *       x_1^{ev_1} = 0, y_1^{ev_1} = sqrt(2)
+ *       expectation of the first harmonic Q-vector in the second subevent:
+ *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
+ *       expectation of the first harmonic Q-vector in the third subevent:
+ *       x_1^{ev_1} = 0, y_1^{ev_1} = sqrt(2)
+ *       expectation of the first harmonic Q-vector in the fourth subevent:
+ *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
+ *
+ */
+TEST(QVectorAction, Basic2D) {
+  auto axes = Qn::MakeAxes(Qn::AxisD("eta", 2, 2, 4), Qn::AxisD("pt", 2, 0, 2));
+  auto q_action = Qn::MakeQVectorHelper("test", {1, 2, 3, 4}, axes);
+  int si = 8;
+  ROOT::RVec<double> phis(si);
+  ROOT::RVec<double> weights(si);
+  ROOT::RVec<double> etas(si);
+  ROOT::RVec<double> pts(si);
+  double angle = 1.;
+  for (int i = 0.; i < si; ++i) {
+    if (angle > 7) angle = 1;
+    phis[i] = angle / 8 * 2 * TMath::Pi();
+    weights[i] = (double)1;
+    angle = angle + 2.;
+    if (i == 0 || i == 1) {
+      etas[i] = 2.;
+      pts[i] = 0.;
+    }
+    if (i == 2 || i == 3) {
+      etas[i] = 2.;
+      pts[i] = 1.;
+    }
+    if (i == 4 || i == 5) {
+      etas[i] = 3.;
+      pts[i] = 0.;
+    }
+    if (i == 6 || i == 7) {
+      etas[i] = 3.;
+      pts[i] = 1.;
+    }
+  }
+  auto q = q_action(phis, weights, etas, pts);
+  EXPECT_NEAR(q.At(0).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(0).y(1), std::sqrt(2), 1e-5);
+  EXPECT_NEAR(q.At(1).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(1).y(1), -std::sqrt(2), 1e-5);
+  EXPECT_NEAR(q.At(2).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(2).y(1), std::sqrt(2), 1e-5);
+  EXPECT_NEAR(q.At(3).x(1), 0., 1e-5);
+  EXPECT_NEAR(q.At(3).y(1), -std::sqrt(2), 1e-5);
+}
+
+/**
+ * Check the the constructor and the definition of a Q-vector with 2 subevents
+ * using the RDataFrame. input 4 phi angles (45 deg, 135 deg, 215 deg, 305 deg)
+ *       4 weights (1, 1, 1, 1)
+ *       4 etas    (25, 25, 75, 75)
+ *       subevents are binned in eta with the bin edges (0, 50, 100)
+ *       expectation of the first harmonic Q-vector in the first subevent:
+ *       x_1^{ev_1} = 0, y_1^{ev_1} = sqrt(2)
+ *       expectation of the first harmonic Q-vector in the second subevent:
+ *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
+ *       All events in the DataFrame should give the same result.
+ */
+TEST(QVectorAction, RDataFrame) {
+  ROOT::RDataFrame df(8);
+  std::size_t phi_size = 4;
+  auto df1 = df.Define("phis",
+                       [phi_size]() {
+                         ROOT::RVec<double> phis(phi_size);
+                         double angle = 1.;
+                         for (int i = 0.; i < phi_size; ++i) {
+                           phis[i] = angle / 8 * 2 * TMath::Pi();
+                           angle = angle + 2.;
+                         }
+                         return phis;
+                       },
+                       {})
+                 .Define("weights",
+                         [phi_size]() {
+                           ROOT::RVec<double> weights(phi_size);
+                           for (int i = 0.; i < phi_size; ++i) {
+                             weights[i] = 1;
+                           }
+                           return weights;
+                         },
+                         {})
+                 .Define("etas",
+                         [phi_size]() {
+                           ROOT::RVec<double> etas(phi_size);
+                           for (int i = 0.; i < phi_size; ++i) {
+                             if (i < phi_size / 2) {
+                               etas[i] = (double)25.;
+                             } else {
+                               etas[i] = (double)75.;
+                             }
+                           }
+                           return etas;
+                         },
+                         {});
+  auto axes = Qn::MakeAxes(Qn::AxisD("t1", 2, 0, 100));
+  auto q_action = Qn::MakeQVectorHelper("test", {1, 2, 3, 4}, axes);
+  auto df2 =
+      df1.Define(q_action.GetName(), q_action, {"phis", "weights", "etas"});
+  auto qs = df2.Take<Qn::DataContainerQVector>("test");
+  for (int i = 0; i < 8; ++i) {
+    auto q = qs.GetValue().at(i);
+    EXPECT_NEAR(q.At(0).x(1), 0., 1e-5);
+    EXPECT_NEAR(q.At(0).y(1), std::sqrt(2), 1e-5);
+    EXPECT_NEAR(q.At(1).x(1), 0., 1e-5);
+    EXPECT_NEAR(q.At(1).y(1), -std::sqrt(2), 1e-5);
+  }
+}

--- a/src/dataframe/correction/RecenterAction.test.cpp
+++ b/src/dataframe/correction/RecenterAction.test.cpp
@@ -15,8 +15,50 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <ROOT/RDataFrame.hxx>
 #include <gtest/gtest.h>
 
+#include "AverageHelper.hpp"
+#include "AxesConfiguration.hpp"
 #include "RecenterAction.hpp"
 
 TEST(RecenterActionUnitTest, Constructor) { ASSERT_EQ(1, 1); }
+
+TEST(RecenterActionUnitTest, RDataFrame) {
+  ROOT::RDataFrame df(100);
+  std::size_t phi_size = 4;
+  Qn::DataContainerQVector qvec_proto;
+  auto event_axis = Qn::AxisD("event", 2, 0, 2);
+  for (auto &q : qvec_proto) {
+    q.ActivateHarmonic(1);
+    q.InitializeHarmonics();
+  }
+  auto df0 = df.DefineSlotEntry("event",
+                                [](unsigned int, ULong64_t entry) {
+                                  double a = 0;
+                                  if (entry > 90) a = 1.;
+                                  return a;
+                                },
+                                {});
+  auto df1 = df0.Define("q",
+                        [qvec_proto](double event) -> Qn::DataContainerQVector {
+                          auto ret = qvec_proto;
+                          for (int i = 0; i < 100; ++i) {
+                            ret.At(0).Add(0, 1.);
+                          }
+                          ret.At(0).CheckQuality();
+                          ret.At(0).Normal(Qn::QVector::Normalization::M);
+                          return ret;
+                        },
+                        {"event"});
+  auto axes = Qn::MakeAxes(event_axis);
+  auto res = Qn::Correction::MakeRecenterAction("test", axes, "q");
+  TTreeReader reader;
+  auto rec = Qn::AverageHelper(res)
+                 .SetInitializationWithInitializationObject(&qvec_proto)
+                 .BookMe(df1);
+  auto resv = rec.GetValue();
+  auto dfc = resv.ApplyCorrection(df1);
+  auto qs = dfc.Take<Qn::DataContainerQVector>("q").GetValue();
+  auto qsc = dfc.Take<Qn::DataContainerQVector>(resv.GetName()).GetValue();
+}

--- a/src/dataframe/correlation/CorrelationAction.test.cpp
+++ b/src/dataframe/correlation/CorrelationAction.test.cpp
@@ -1,0 +1,74 @@
+// Flow Vector Correction Framework
+//
+// Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
+// Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
+// For a full list of contributors please see docs/Credits
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#include <ROOT/RDataFrame.hxx>
+#include <gtest/gtest.h>
+
+#include "AverageHelper.hpp"
+#include "AxesConfiguration.hpp"
+#include "CorrelationAction.hpp"
+#include "ReSampleHelper.hpp"
+
+/**
+ * Basic test of the correlation
+ * input: 1D Qvector with first harmonic Q vector of (0., 0.70710678)
+ *        Event axes with 2 bins
+ *        no event-to-event fluctuation
+ *        correlation function: c = Qy_1 + Qx_2
+ * expectation: mean of all events should be 0.70710678
+ *              number of events in the first class should be 91
+ *              number of events in the second class should be 9
+ */
+TEST(CorrelationAction, BasicIntegratedQ) {
+  ROOT::RDataFrame df(100);
+  auto event_axes = Qn::MakeAxes(Qn::AxisD("event", 2, 0, 2));
+  auto q = Qn::DataContainerQVector();
+  q.At(0).ActivateHarmonic(1);
+  q.At(0).InitializeHarmonics();
+  auto df1 = df.DefineSlotEntry("event",
+                                [](unsigned int, ULong64_t entry) {
+                                  double a = 0;
+                                  if (entry > 90) a = 1.;
+                                  return a;
+                                },
+                                {})
+                 .Define("q",
+                         [q](double event) -> Qn::DataContainerQVector {
+                           auto ret = q;
+                           for (int i = 0; i < 100; ++i) {
+                             ret.At(0).Add(3. / 4 * TMath::Pi(), 1.);
+                             ret.At(0).Add(1. / 4 * TMath::Pi(), 1.);
+                           }
+                           ret.At(0).CheckQuality();
+                           ret.At(0) =
+                               ret.At(0).Normal(Qn::QVector::Normalization::M);
+                           return ret;
+                         },
+                         {"event"});
+  auto dfs = Qn::Correlation::Resample(df1, 10);
+
+  auto f_test = [](const Qn::QVector &a) { return a.x(1) + a.y(1); };
+  std::vector<Qn::DataContainerQVector> initialization{q};
+  auto correlation = Qn::Correlation::MakeCorrelationAction(
+      "test", f_test, {"q"}, {Qn::Stats::Weights::OBSERVABLE}, event_axes, 0);
+  auto avg = Qn::MakeAverageHelper(correlation);
+  auto res = avg.SetInitializationWithInitializationObject(&initialization)
+                 .BookMe(dfs);
+  auto data_container = res->GetDataContainer();
+  EXPECT_NEAR(data_container.At(0).Mean(), 0.70710678, 1e-5);
+  EXPECT_EQ(data_container.At(0).N(), 91);
+  EXPECT_EQ(data_container.At(1).N(), 9);
+}

--- a/tests/simulation/ToyMCSimulation.cpp
+++ b/tests/simulation/ToyMCSimulation.cpp
@@ -239,19 +239,15 @@ auto dfs = Qn::Correlation::Resample(df, n_samples);
 auto detector_names_trk = CreateDetectorNames(detectors_trk.size(), "DetTrk", correction_steps);
 
 constexpr auto kObs = Qn::Stats::Weights::OBSERVABLE;
-auto event_axes = Qn::EventAxes(event);
+auto event_axes = Qn::MakeAxes(event);
 
 std::map<std::string, ROOT::RDF::RResultPtr<Qn::Correlation::CorrelationActionBase>> correlations;
 for (const auto &detector : detector_names_trk) {
 std::array<std::string, 1> inputs{detector};
 std::string correlation_name{"v22"};
-auto c22 = Qn::EventAverage(Qn::Correlation::Correlation(
-    correlation_name + detector,
-    Qn::Correlation::TwoParticle::Cumulant(2),
-    inputs,
-    {kObs},
-    event_axes,
-    n_samples))
+auto c22 = Qn::MakeAverageHelper(Qn::Correlation::MakeCorrelationAction(correlation_name + detector,
+                                                                        Qn::Correlation::TwoParticle::Cumulant(2),
+                                                                        inputs, {kObs}, event_axes, n_samples))
     .BookMe(dfs);
 correlations.emplace(detector + "_" + correlation_name, c22);
 }


### PR DESCRIPTION
added additional unit tests.

With this pull request we should be able to create Q-vectors from std::vectors<double> phi and std::vectors<double> weights , additional detector parameters for a possible binning. These variables should be in the tree accessed by the data frame. In addition a local axisconfiguration is required to define the binning. The std::vectors should be converted by the RDataFrame to ROOT::RVec which will be read by the QVectorAction. This means one can do an analysis only using the RDataFrame without using the "correction" step. Maybe this can be used together with the analysistree @viktorklochkov?
best regards,
Lukas