### PR TITLE
Added the QVectorNormalizationHelper

### DIFF
--- a/include/base/QnTools/Axis.hpp
+++ b/include/base/QnTools/Axis.hpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include "Rtypes.h"
 
@@ -73,7 +74,10 @@ class Axis {
                      std::end(bin_edges_),
                      std::begin(axis.bin_edges_),
                      std::back_inserter(result),
-                     [](const T &a, const T &b) { return a == b; });
+                     [](const T &a, const T &b) {
+                       double epsilon = std::fabs(a*1e-3);
+                       return std::fabs(a-b) < epsilon;
+                     });
       same_bins = std::all_of(std::begin(result), std::end(result), [](bool a) { return a; });
     }
     return name_ == axis.name_ && same_bins;

--- a/include/base/QnTools/QVector.hpp
+++ b/include/base/QnTools/QVector.hpp
@@ -102,6 +102,15 @@ class QVector {
     MAGNITUDE///< \f$ \mbox{Q'} = \frac{\mbox{Q}}{|\mbox{Q}|} \f$
   };
 
+  static std::string GetNormalizationName(Normalization normal) {
+    switch (normal){
+      case Normalization::NONE: return "None";
+      case Normalization::M: return "M";
+      case Normalization::SQRT_M: return "SqrtM";
+      case Normalization::MAGNITUDE: return "Magnitude";
+    }
+  }
+
   QVector() = default;
 
   virtual ~QVector() = default;

--- a/include/correction/QnTools/InputVariableManager.hpp
+++ b/include/correction/QnTools/InputVariableManager.hpp
@@ -59,7 +59,7 @@ class OutputValueVector {
  * @brief updates the value. To be called every event.
  */
   void UpdateValue() {
-    for (int i = 0; i < var_->size(); ++i) {
+    for (unsigned int i = 0; i < var_->size(); ++i) {
       value_[i] = (T) (*var_->at(i));
     }
   }

--- a/src/base/Axis.test.cpp
+++ b/src/base/Axis.test.cpp
@@ -1,4 +1,4 @@
-// Qn Tools
+// Flow Vector Correction Framework
 //
 // Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
 // Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
@@ -14,18 +14,13 @@
 // GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#ifndef QNTOOLS_QNDATAFRAME_H_
-#define QNTOOLS_QNDATAFRAME_H_
-// common headers
-#include "AverageHelper.hpp"
-#include "AxesConfiguration.hpp"
-#include "EqualBinningHelper.hpp"
-#include "QVectorHelper.hpp"
-#include "QVectorNormalizationHelper.hpp"
-// correction step
-#include "RecenterAction.hpp"
-// correlation step
-#include "CorrelationAction.hpp"
-#include "CorrelationFunctions.hpp"
-#include "ReSampleHelper.hpp"
-#endif  // QNTOOLS_QNDATAFRAME_H_
+
+#include <gtest/gtest.h>
+
+#include "Axis.hpp"
+
+TEST(AxisUnitTest, Comparison) {
+  Qn::AxisD axis1("axis1",10.,0.,10.);
+  Qn::AxisD axis2("axis1",10.,0.,10.);
+  EXPECT_TRUE(axis1==axis2);
+}

--- a/src/dataframe/CMakeLists.txt
+++ b/src/dataframe/CMakeLists.txt
@@ -32,6 +32,7 @@ IF (CMAKE_BUILD_TYPE MATCHES Debug)
             common/AverageHelper.test.cpp
             common/AxesConfiguration.test.cpp
             common/QVectorHelper.test.cpp
+            common/QVectorNormalizationHelper.test.cpp
             correction/RecenterAction.test.cpp
             correlation/CorrelationAction.test.cpp
             )

--- a/src/dataframe/common/AverageHelper.hpp
+++ b/src/dataframe/common/AverageHelper.hpp
@@ -157,14 +157,14 @@ class AverageHelper : public RActionImpl<AverageHelper<Action>> {
    */
   void InitTask(TTreeReader *reader, unsigned int slot) {
     if (!is_configured_[slot]) {
-      if (reader) {
-        TTreeReader local_reader(reader->GetTree());
-        results_[slot]->Initialize(local_reader);
+      if (initialization_object_) {
+        results_[slot]->Initialize(*initialization_object_);
       } else if (external_reader_) {
         TTreeReader local_reader(external_reader_->GetTree());
         results_[slot]->Initialize(local_reader);
-      } else if (initialization_object_) {
-        results_[slot]->Initialize(*initialization_object_);
+      } else if (reader) {
+        TTreeReader local_reader(reader->GetTree());
+        results_[slot]->Initialize(local_reader);
       } else {
         throw std::runtime_error(
             "The Action has not Initialized. In case of cached data input, "

--- a/src/dataframe/common/QVectorHelper.hpp
+++ b/src/dataframe/common/QVectorHelper.hpp
@@ -105,6 +105,8 @@ class QVectorHelper<AxesConfig, std::tuple<DetectorParameters...>> {
     return ret;
   }
 
+  Qn::DataContainerQVector* GetPrototype() {return &q_vector_;}
+
  private:
   std::string name_;
   AxesConfig axes_;

--- a/src/dataframe/common/QVectorHelper.test.cpp
+++ b/src/dataframe/common/QVectorHelper.test.cpp
@@ -34,7 +34,7 @@
  *       x_1^{ev_1} = 0, y_1^{ev_1} = 0
  *
  */
-TEST(QVectorAction, BasicIntegrated) {
+TEST(QVectorHelper, BasicIntegrated) {
   auto q_action = Qn::MakeQVectorHelper("test", {1, 2, 3, 4});
   int si = 4;
   ROOT::RVec<double> phis(si);
@@ -67,7 +67,7 @@ TEST(QVectorAction, BasicIntegrated) {
  *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
  *
  */
-TEST(QVectorAction, Basic1D) {
+TEST(QVectorHelper, Basic1D) {
   auto axes = Qn::MakeAxes(Qn::AxisD("t1", 2, 0, 100));
   Qn::QVectorHelper<decltype(axes), std::tuple<ROOT::RVec<double>>> q_action(
       "test", {1, 2, 3, 4}, axes);
@@ -108,7 +108,7 @@ TEST(QVectorAction, Basic1D) {
  *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
  *
  */
-TEST(QVectorAction, Basic2D) {
+TEST(QVectorHelper, Basic2D) {
   auto axes = Qn::MakeAxes(Qn::AxisD("eta", 2, 2, 4), Qn::AxisD("pt", 2, 0, 2));
   auto q_action = Qn::MakeQVectorHelper("test", {1, 2, 3, 4}, axes);
   int si = 8;
@@ -162,7 +162,7 @@ TEST(QVectorAction, Basic2D) {
  *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)
  *       All events in the DataFrame should give the same result.
  */
-TEST(QVectorAction, RDataFrame) {
+TEST(QVectorHelper, RDataFrame) {
   ROOT::RDataFrame df(8);
   std::size_t phi_size = 4;
   auto df1 = df.Define("phis",

--- a/src/dataframe/common/QVectorNormalizationHelper.hpp
+++ b/src/dataframe/common/QVectorNormalizationHelper.hpp
@@ -1,0 +1,49 @@
+// Flow Vector Correction Framework
+//
+// Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
+// Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
+// For a full list of contributors please see docs/Credits
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef QNTOOLS_QVECTORNORMALIZATIONHELPER_HPP_
+#define QNTOOLS_QVECTORNORMALIZATIONHELPER_HPP_
+
+#include "DataContainer.hpp"
+#include "QVector.hpp"
+
+namespace Qn {
+class QVectorNormalizationHelper {
+ public:
+  using Normalization = typename Qn::QVector::Normalization;
+
+  explicit QVectorNormalizationHelper(Normalization normalization)
+      : normalization_(normalization) {}
+
+  [[nodiscard]] std::string GetName(const std::string& name) const {
+    return name + "_norm_" + Qn::QVector::GetNormalizationName(normalization_);
+  }
+
+  Qn::DataContainerQVector operator()(
+      const Qn::DataContainerQVector& q_vector) {
+    auto ret = q_vector;
+    for (unsigned int i = 0; i < q_vector.size(); ++i) {
+      ret[i] = q_vector[i].Normal(normalization_);
+    }
+    return ret;
+  }
+
+ private:
+  Normalization normalization_;
+};
+}  // namespace Qn
+#endif  // QNTOOLS_QVECTORNORMALIZATIONHELPER_HPP_

--- a/src/dataframe/common/QVectorNormalizationHelper.test.cpp
+++ b/src/dataframe/common/QVectorNormalizationHelper.test.cpp
@@ -1,0 +1,93 @@
+// Flow Vector Correction Framework
+//
+// Copyright (C) 2020  Lukas Kreis Ilya Selyuzhenkov
+// Contact: l.kreis@gsi.de; ilya.selyuzhenkov@gmail.com
+// For a full list of contributors please see docs/Credits
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#include <iostream>
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RVec.hxx>
+#include <gtest/gtest.h>
+
+#include "AxesConfiguration.hpp"
+#include "QVectorHelper.hpp"
+#include "QVectorNormalizationHelper.hpp"
+
+/**
+ * Check the the constructor and the definition of a Q-vector with 2 subevents
+ * using the RDataFrame. input 4 phi angles (45 deg, 135 deg, 215 deg, 305 deg)
+ * All qvectors are normalized by the number of contributors (2).
+ *       4 weights (1, 1, 1, 1)
+ *       4 etas    (25, 25, 75, 75)
+ *       subevents are binned in eta with the bin edges (0, 50, 100)
+ *       expectation of the first harmonic Q-vector in the first subevent:
+ *       x_1^{ev_1} = 0, y_1^{ev_1} = sqrt(2)/2
+ *       expectation of the first harmonic Q-vector in the second subevent:
+ *       x_1^{ev_2} = 0, y_1^{ev_2} = -sqrt(2)/2
+ *       All events in the DataFrame should give the same result.
+ */
+TEST(QVectorNormalizationHelper, RDataFrame) {
+ROOT::RDataFrame df(8);
+std::size_t phi_size = 4;
+auto df1 = df.Define("phis",
+                     [phi_size]() {
+                       ROOT::RVec<double> phis(phi_size);
+                       double angle = 1.;
+                       for (int i = 0.; i < phi_size; ++i) {
+                         phis[i] = angle / 8 * 2 * TMath::Pi();
+                         angle = angle + 2.;
+                       }
+                       return phis;
+                     },
+                     {})
+    .Define("weights",
+            [phi_size]() {
+              ROOT::RVec<double> weights(phi_size);
+              for (int i = 0.; i < phi_size; ++i) {
+                weights[i] = 1;
+              }
+              return weights;
+            },
+            {})
+    .Define("etas",
+            [phi_size]() {
+              ROOT::RVec<double> etas(phi_size);
+              for (int i = 0.; i < phi_size; ++i) {
+                if (i < phi_size / 2) {
+                  etas[i] = (double)25.;
+                } else {
+                  etas[i] = (double)75.;
+                }
+              }
+              return etas;
+            },
+            {});
+auto axes = Qn::MakeAxes(Qn::AxisD("t1", 2, 0, 100));
+auto q_action = Qn::MakeQVectorHelper("test", {1, 2, 3, 4}, axes);
+auto q_normalization = Qn::QVectorNormalizationHelper(Qn::QVectorNormalizationHelper::Normalization::M);
+auto df2 =
+    df1.Define(q_action.GetName(), q_action, {"phis", "weights", "etas"})
+       .Define(q_normalization.GetName(q_action.GetName()), q_normalization, {q_action.GetName()});
+auto qs = df2.Take<Qn::DataContainerQVector>("test");
+auto qsnorm = df2.Take<Qn::DataContainerQVector>("test_norm_M");
+
+for (int i = 0; i < 8; ++i) {
+auto q = qs.GetValue().at(i);
+auto qnorm = qsnorm.GetValue().at(i);
+EXPECT_NEAR(qnorm.At(0).x(1), 0., 1e-5);
+EXPECT_NEAR(qnorm.At(0).y(1), std::sqrt(2)/2, 1e-5);
+EXPECT_NEAR(qnorm.At(1).x(1), 0., 1e-5);
+EXPECT_NEAR(qnorm.At(1).y(1), -std::sqrt(2)/2, 1e-5);
+}
+}


### PR DESCRIPTION
Fixes order of initialization: first initialisation object, then external, then internal.
Added GetPrototype to make initialisation easier.
removes warning about unsigned signed comparison.
Adds the QVectorNormalizationHelper.
gives normalization specific name to QVector.
fixes axis comparisons.