### PR TITLE
Issue 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(src/dataframe)
 # if debug enable tests
 IF (CMAKE_BUILD_TYPE MATCHES Debug)
     add_subdirectory(tests/simulation)
+    add_subdirectory(tests/correction)
 ENDIF (CMAKE_BUILD_TYPE MATCHES Debug)
 
 # Install configuration

--- a/include/base/QnTools/Cuts.hpp
+++ b/include/base/QnTools/Cuts.hpp
@@ -29,8 +29,8 @@ namespace Qn {
 /**
  * Base class of the Cut.
  */
-struct CutBase {
-  virtual ~CutBase() = default;
+struct ICut {
+  virtual ~ICut() = default;
   virtual bool Check() const = 0;
   virtual bool Check(unsigned int) const = 0;
   virtual std::string Name() const = 0;
@@ -43,7 +43,7 @@ struct CutBase {
  * @tparam T Type of variable
  */
 template<typename VAR, typename... T>
-class Cut : public CutBase {
+class Cut : public ICut {
  public:
   Cut(VAR (&arr)[sizeof...(T)], std::function<bool(T...)> lambda, std::string name)
       : lambda_(lambda), name_(std::move(name)) {
@@ -96,7 +96,7 @@ std::unique_ptr<Cut<VAR, CutDataType<T, Is>...>> MakeUniqueCutImpl(std::index_se
  * @return Returns a unique pointer to the cut.
  */
 template<typename T, std::size_t N, typename FUNC, typename VAR>
-std::unique_ptr<CutBase> MakeUniqueCut(VAR (&arr)[N], FUNC &&func, std::string name) {
+std::unique_ptr<ICut> MakeUniqueCut(VAR (&arr)[N], FUNC &&func, std::string name) {
   return Details::MakeUniqueCutImpl<T>(std::make_index_sequence<N>{}, arr, std::forward<FUNC>(func), name);
 }
 }// namespace Qn

--- a/include/base/QnTools/Cuts.hpp
+++ b/include/base/QnTools/Cuts.hpp
@@ -27,7 +27,7 @@
 namespace Qn {
 
 /**
- * Base class of the Cut.
+ * Interface class of the Cut.
  */
 struct ICut {
   virtual ~ICut() = default;
@@ -36,16 +36,37 @@ struct ICut {
   virtual std::string Name() const = 0;
 };
 
+namespace Details {
+
+template <typename T>
+using remove_cvref_t = typename std::remove_cv<std::remove_reference_t<T>>::type;
+
+template <typename Function, typename ... Arg>
+constexpr bool is_static_cut_v = std::is_same_v<bool, std::invoke_result_t<Function&&, Arg...>>;
+
+template <typename Function, typename T>
+constexpr bool is_dynamic_cut_v = std::is_same_v<bool, std::invoke_result_t<Function&&,const std::vector<remove_cvref_t<T>>>>;
+
+template <typename Variable>
+using variable_get_t = std::remove_pointer_t<decltype(std::declval<const Variable>().Get())>;
+
+template<typename T, std::size_t>
+using enumerated_arg = T &;
+
+
+}// namespace Details
+
 /**
  * Template class of a cut applied in the correction step.
  * Number of dimensions is determined by the signature of the cut function
  * and by the size of the variables array passed to the constructor.
  * @tparam T Type of variable
  */
-template<typename VAR, typename... T>
+template<typename Variable, typename... T>
 class StaticCut : public ICut {
  public:
-  StaticCut(VAR (&arr)[sizeof...(T)], std::function<bool(T...)> lambda, std::string name)
+  StaticCut() = delete;
+  StaticCut(Variable (&arr)[sizeof...(T)], std::function<bool(T...)> lambda, std::string name)
       : lambda_(lambda), name_(std::move(name)) {
     int i = 0;
     for (auto &a : arr) {
@@ -53,6 +74,14 @@ class StaticCut : public ICut {
       ++i;
     }
   }
+
+  StaticCut(
+      const std::array<Variable, sizeof...(T)> &args,
+      std::function<bool (T...)> lambda,
+      std::string name
+      ) : variables_(args), lambda_(lambda), name_(std::move(name)) {}
+
+
   bool Check(const unsigned int i_channel) const override {
     return CheckImpl(i_channel, std::make_index_sequence<sizeof...(T)>{});
   }
@@ -71,44 +100,83 @@ class StaticCut : public ICut {
   bool CheckImpl(const unsigned int i, std::index_sequence<I...>) const {
     return lambda_(*(variables_[I].Get() + i)...);
   }
-  std::array<VAR, sizeof...(T)> variables_;/// array of the variables used in the cut.
+
+  std::array<Variable, sizeof...(T)> variables_;/// array of the variables used in the cut.
   std::function<bool(T...)> lambda_;       /// function used to evaluate the cut.
+  std::string name_;
+};
+
+
+template <typename Variable>
+class DynamicCut : public ICut {
+ public:
+  typedef typename Details::remove_cvref_t<Details::variable_get_t<Variable>> lambda_arg_ele_t;
+  typedef typename std::vector<lambda_arg_ele_t> lambda_arg_t;
+  typedef typename std::function<bool (const lambda_arg_t&)> lambda_t;
+
+  DynamicCut(const std::vector<Variable> &variables,
+             lambda_t lambda,
+             std::string name)
+      : variables_(variables), lambda_(lambda), name_(std::move(name)) {
+  }
+  bool Check() const override { return CheckImpl(0); }
+  bool Check(unsigned int i) const override { return CheckImpl(i); }
+  std::string Name() const override { return name_; }
+
+ private:
+  bool CheckImpl(unsigned int channel_id) const {
+    lambda_arg_t lambda_args(variables_.size());
+    std::transform(std::begin(variables_), std::end(variables_),
+                     std::begin(lambda_args), [this,channel_id] (const Variable& v) {
+      return *(v.Get() + channel_id);
+    });
+
+    return lambda_(lambda_args);
+  }
+
+
+  std::vector<Variable> variables_;
+  lambda_t lambda_;
   std::string name_;
 };
 
 namespace Details {
 
-template <typename Function, typename ... Arg>
-constexpr bool is_static_cut_v = std::is_same_v<bool, std::invoke_result_t<Function, Arg...>>;
-
-template <typename Function, typename T>
-constexpr bool is_dynamic_cut_v = std::is_same_v<bool, std::invoke_result<Function, const std::vector<std::decay_t<T>>&>>;
-
-template <typename Variable>
-using input_variable_t = std::remove_pointer_t<decltype(std::declval<const Variable>().Get())>;
-
-template<typename T, std::size_t>
-using EnumeratedCutArg = T &;
-
 template<typename Variable, std::size_t N, typename Function, std::size_t... Is>
-typename std::enable_if_t<is_static_cut_v<Function, EnumeratedCutArg<input_variable_t<Variable>, Is>...>,std::unique_ptr<ICut>>
-MakeUniqueCutImpl(std::index_sequence<Is...>, Variable (&arr)[N], Function &&func, std::string name) {
-  return std::make_unique<StaticCut<Variable, EnumeratedCutArg<input_variable_t<Variable>, Is>...>>(arr, std::forward<Function>(func), name);
+typename std::enable_if_t<is_static_cut_v<Function, enumerated_arg<variable_get_t<Variable>, Is>...>,std::unique_ptr<ICut>>
+MakeStaticCutImpl(std::index_sequence<Is...>, const std::array<Variable, N> &arr, Function &&func, std::string name) {
+  return std::make_unique<StaticCut<Variable, enumerated_arg<variable_get_t<Variable>, Is>...>>(arr, std::forward<Function>(func), name);
 }
-}// namespace Details
+
+
+template<typename Variable, typename Function>
+typename std::enable_if_t<is_dynamic_cut_v<Function, variable_get_t<Variable>>,std::unique_ptr<ICut>>
+MakeDynamicCutImpl(const std::vector<Variable> &arr, Function &&func, std::string name) {
+  return std::make_unique<DynamicCut<Variable>>(arr, func, name);
+}
+
+
+}
 
 /**
  * Function which create a unique_ptr of a cut of n variables.
  * @tparam N length of the variable array.
- * @tparam FUNC type of the cut function
+ * @tparam Function type of the cut function
  * @param arr array of variables
  * @param func cut function
  * @return Returns a unique pointer to the cut.
  */
-template<typename T, std::size_t N, typename FUNC, typename VAR>
-std::unique_ptr<ICut> MakeUniqueCut(VAR (&arr)[N], FUNC &&func, std::string name) {
-  return Details::MakeUniqueCutImpl(std::make_index_sequence<N>{}, arr, std::forward<FUNC>(func), name);
+template<std::size_t N, typename Function, typename Variable>
+std::unique_ptr<ICut> MakeUniqueCut(const std::array<Variable, N> &arr, Function &&func, std::string name) {
+  return Details::MakeStaticCutImpl(std::make_index_sequence<N>{}, arr, std::forward<Function>(func), name);
 }
+
+template <typename Function, typename Variable>
+std::unique_ptr<ICut> MakeUniqueCut(const std::vector<Variable> &arr, Function &&func, std::string name) {
+  return Details::MakeDynamicCutImpl(arr, std::forward<Function>(func), name);
+}
+
+
 }// namespace Qn
 
 

--- a/include/correction/QnTools/CorrectionCuts.hpp
+++ b/include/correction/QnTools/CorrectionCuts.hpp
@@ -35,7 +35,7 @@ namespace Qn {
 
 class CorrectionCut {
  public:
-  using CallBack = std::function<std::unique_ptr<Qn::CutBase>(const Qn::InputVariableManager &)>;
+  using CallBack = std::function<std::unique_ptr<Qn::ICut>(const Qn::InputVariableManager &)>;
   explicit CorrectionCut(CallBack callback) : callback_(std::move(callback)) {}
   ~CorrectionCut() = default;
   CorrectionCut(CorrectionCut &&) = default;
@@ -53,7 +53,7 @@ class CorrectionCut {
   }
   CorrectionCut::CallBack GetCallBack() const { return callback_; }
  private:
-  std::unique_ptr<CutBase> cut_;
+  std::unique_ptr<ICut> cut_;
   CorrectionCut::CallBack callback_;
 };
 

--- a/include/correction/QnTools/CorrectionManager.hpp
+++ b/include/correction/QnTools/CorrectionManager.hpp
@@ -147,7 +147,7 @@ class CorrectionManager {
     return;
   }
 
-  template<std::size_t N, typename FUNCTION>
+  template<std::size_t N, typename Function>
   void AddCutOnDetector(const std::string &detector_name,
                         const char *const (&variable_names)[N],
                         Function cut_function,

--- a/include/correction/QnTools/CorrectionManager.hpp
+++ b/include/correction/QnTools/CorrectionManager.hpp
@@ -130,10 +130,23 @@ class CorrectionManager {
     detectors_.AddDetector(name, type, phi, weight, radial_offset, axes, harmonics, norm);
   }
 
-  template<std::size_t N, typename FUNCTION>
+  template<std::size_t N, typename Function>
   void AddCutOnDetector(const std::string &detector_name,
                         const char *const (&variable_names)[N],
-                        FUNCTION cut_function,
+                        Function cut_function,
+                        const std::string &cut_description) {
+    std::array<std::string, N> variable_names_arr;
+    std::copy(std::begin(variable_names), std::end(variable_names), std::begin(variable_names_arr));
+    bool is_channel_wise = variable_manager_.FindVariable(variable_names_arr[0]).size() > 1;
+    detectors_.AddCut(detector_name,
+                      CallBacks::MakeCut(variable_names_arr, cut_function, cut_description),
+                      is_channel_wise);
+  }
+
+  template<typename Function>
+  void AddCutOnDetector(const std::string &detector_name,
+                        const std::vector<std::string> &variable_names,
+                        Function cut_function,
                         const std::string &cut_description) {
     bool is_channel_wise = variable_manager_.FindVariable(variable_names[0]).size() > 1;
     detectors_.AddCut(detector_name,

--- a/include/correction/QnTools/CorrectionManager.hpp
+++ b/include/correction/QnTools/CorrectionManager.hpp
@@ -43,7 +43,7 @@
 
 namespace Qn {
 class CorrectionManager {
-  using CutCallBack =  std::function<std::unique_ptr<CutBase>(Qn::InputVariableManager *)>;
+  using CutCallBack =  std::function<std::unique_ptr<ICut>(Qn::InputVariableManager *)>;
  public:
   CorrectionManager() = default;
   virtual ~CorrectionManager() = default;

--- a/tests/correction/CMakeLists.txt
+++ b/tests/correction/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES TestCuts.cpp)
+add_executable(QnToolsCorrectionTests ${SOURCES})
+target_link_libraries(QnToolsCorrectionTests  PRIVATE gtest_main gmock QnToolsCorrection QnToolsDataFrame PRIVATE ROOT::Core ROOT::Hist)
+gtest_add_tests(TARGET QnToolsCorrectionTests  )

--- a/tests/correction/TestCuts.cpp
+++ b/tests/correction/TestCuts.cpp
@@ -91,19 +91,19 @@ TEST_F(CutsTest, StaticCut) {
   delete mocks;
 }
 
-//TEST_F(CutsTest, DynamicCut) {
-//  auto mocks = new CutMocksHolder;
-//  EXPECT_CALL(*mocks, dynamicCutF).Times(1000).WillRepeatedly(Return(true));
-//
-//  manager->AddCutOnDetector(
-//      "DetPhi", {"pt"},
-//      [mocks](const std::vector<double>& args) { return mocks->dynamicCutF(args); }, "static_cut");
-//
-//  manager->InitializeOnNode();
-//
-//  Fill();
-//
-//  delete mocks;
-//}
+TEST_F(CutsTest, DynamicCut) {
+  auto mocks = new CutMocksHolder;
+  EXPECT_CALL(*mocks, dynamicCutF).Times(1000).WillRepeatedly(Return(true));
+
+  manager->AddCutOnDetector(
+      "DetPhi", std::vector<std::string>({"pt"}),
+      [mocks](const std::vector<double>& args) { return mocks->dynamicCutF(args); }, "static_cut");
+
+  manager->InitializeOnNode();
+
+  Fill();
+
+  delete mocks;
+}
 
 }  // namespace

--- a/tests/correction/TestCuts.cpp
+++ b/tests/correction/TestCuts.cpp
@@ -15,12 +15,16 @@ using namespace ::testing;
 using namespace Qn;
 
 struct ICutFHolder {
-  virtual bool staticCutF(const double &v) = 0;
+  virtual bool staticCutF1(const double &v) = 0;
+  virtual bool staticCutF2(double v) = 0;
+  virtual bool staticCutF3(int v) = 0;
   virtual bool dynamicCutF(const std::vector<double> &vargs) = 0;
 };
 
 struct CutMocksHolder : public ICutFHolder {
-  MOCK_METHOD(bool, staticCutF, (const double &v), (override));
+  MOCK_METHOD(bool, staticCutF1, (const double &v), (override));
+  MOCK_METHOD(bool, staticCutF2, (double v), (override));
+  MOCK_METHOD(bool, staticCutF3, (int v), (override));
   MOCK_METHOD(bool, dynamicCutF, (const std::vector<double> &vargs),
               (override));
 };
@@ -64,11 +68,21 @@ class CutsTest : public ::testing::Test {
 
 TEST_F(CutsTest, StaticCut) {
   auto mocks = new CutMocksHolder;
-  EXPECT_CALL(*mocks, staticCutF).Times(1000).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mocks, staticCutF1).Times(1000).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mocks, staticCutF2).Times(1000).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mocks, staticCutF3).Times(1000).WillRepeatedly(Return(true));
 
   manager->AddCutOnDetector(
       "DetPhi", {"pt"},
-      [mocks](const double &v) { return mocks->staticCutF(v); }, "static_cut");
+      [mocks](const double &v) { return mocks->staticCutF1(v); }, "static_cut_1");
+
+  manager->AddCutOnDetector(
+      "DetPhi", {"pt"},
+      [mocks](double v) { return mocks->staticCutF2(v); }, "static_cut_2");
+
+  manager->AddCutOnDetector(
+      "DetPhi", {"pt"},
+      [mocks](int v) { return mocks->staticCutF3(v); }, "static_cut_2");
 
   manager->InitializeOnNode();
 

--- a/tests/correction/TestCuts.cpp
+++ b/tests/correction/TestCuts.cpp
@@ -1,0 +1,95 @@
+//
+// Created by eugene on 23/07/2020.
+//
+
+#include <vector>
+
+#include <CorrectionManager.hpp>
+#include <TRandom.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace ::testing;
+using namespace Qn;
+
+struct ICutFHolder {
+  virtual bool staticCutF(const double &v) = 0;
+  virtual bool dynamicCutF(const std::vector<double> &vargs) = 0;
+};
+
+struct CutMocksHolder : public ICutFHolder {
+  MOCK_METHOD(bool, staticCutF, (const double &v), (override));
+  MOCK_METHOD(bool, dynamicCutF, (const std::vector<double> &vargs),
+              (override));
+};
+
+class CutsTest : public ::testing::Test {
+ public:
+ protected:
+  void SetUp() override {
+    manager = new CorrectionManager;
+    manager->SetFillValidationQA(false);
+    manager->SetFillOutputTree(false);
+    manager->SetFillCalibrationQA(false);
+
+    manager->AddVariable("phi", 0, 1);
+    manager->AddVariable("pt", 1, 1);
+    manager->AddDetector("DetPhi", DetectorType::TRACK, "phi", "Ones", {},
+                        {1, 2, 3});
+  }
+  void TearDown() override {
+    delete manager;
+  }
+
+  void Fill() {
+    for (int i = 0; i < 1000; ++i) {
+      manager->Reset();
+      if (manager->ProcessEvent()) {
+        manager->GetVariableContainer()[0] =
+            gRandom->Uniform(-TMath::Pi(), TMath::Pi());
+        manager->GetVariableContainer()[1] = gRandom->Exp(1.);
+        manager->FillTrackingDetectors();
+      }
+
+      manager->ProcessCorrections();
+    }
+  }
+
+ protected:
+  CorrectionManager* manager;
+
+};
+
+TEST_F(CutsTest, StaticCut) {
+  auto mocks = new CutMocksHolder;
+  EXPECT_CALL(*mocks, staticCutF).Times(1000).WillRepeatedly(Return(true));
+
+  manager->AddCutOnDetector(
+      "DetPhi", {"pt"},
+      [mocks](const double &v) { return mocks->staticCutF(v); }, "static_cut");
+
+  manager->InitializeOnNode();
+
+  Fill();
+
+  delete mocks;
+}
+
+//TEST_F(CutsTest, DynamicCut) {
+//  auto mocks = new CutMocksHolder;
+//  EXPECT_CALL(*mocks, dynamicCutF).Times(1000).WillRepeatedly(Return(true));
+//
+//  manager->AddCutOnDetector(
+//      "DetPhi", {"pt"},
+//      [mocks](const std::vector<double>& args) { return mocks->dynamicCutF(args); }, "static_cut");
+//
+//  manager->InitializeOnNode();
+//
+//  Fill();
+//
+//  delete mocks;
+//}
+
+}  // namespace


### PR DESCRIPTION
I tried to preserve both static and dynamic ways of Cut definition.

There are two flavours of cuts: StaticCut and DynamicCut implementing ICut interface (CutBase -> ICut). Determination of Cut flavour is based on:

1. whether the number of arguments _N_ defined in compile time or in runtime
2. possibility to invoke _lambda_ with (Args...) if number of arguments is determined during compilation (std::array<std::string, _N_> is passed) - this is _StaticCut_
3. possibility to invoke _lambda_ with (const std::vector<T>&) if number of arguments is not known (std::vector<std::string> is passed) - this is _DynamicCut_

I also wrote few tests (mostly to check compile-time polymorphism)

