### PR TITLE
Ollitrault extrapolation added

### DIFF
--- a/include/base/QnTools/DataContainer.hpp
+++ b/include/base/QnTools/DataContainer.hpp
@@ -969,7 +969,12 @@ template<typename AxisType>
 DataContainer<Stats, AxisType> PowSqrt(const DataContainer<Stats, AxisType> &a, unsigned int k) {
   return a.Map([k](const Stats &x) { return Qn::PowSqrt(x, k); });
 }
-
+// fuction for extrapolation RND-sub Q1Q1 correlation to full event resolution using Ollitrault method
+// NOTE: Only Q1Q1 correlations suitable
+template<typename AxisType>
+DataContainer<Stats, AxisType> OllitraultExtrapolation(const DataContainer<Stats, AxisType> &a, unsigned int k) {
+  return a.Map([k](const Stats &x) { return Qn::OllitraultExtrapolation(x, k); });
+}
 /**
  * Transformation of a DataContainer providing the operation:
  * \f[

--- a/include/base/QnTools/ReSamples.hpp
+++ b/include/base/QnTools/ReSamples.hpp
@@ -139,6 +139,8 @@ class ReSamples {
 
   static ReSamples PowSqrt(const ReSamples &, unsigned int);
 
+  static ReSamples OllitraultExtrapolation( const ReSamples &a, unsigned int k);
+
   static ReSamples Merge(const ReSamples &, const ReSamples &, bool);
 
   static ReSamples MergeStatistics(const ReSamples &, const ReSamples &);

--- a/include/base/QnTools/Stats.hpp
+++ b/include/base/QnTools/Stats.hpp
@@ -191,6 +191,7 @@ class Stats {
   friend Stats Sqrt(const Stats &);
   friend Stats Abs(const Stats &);
   friend Stats PowSqrt(const Stats &, unsigned int);
+  friend Stats OllitraultExtrapolation( const Stats &, unsigned int );
 
   template<typename SAMPLES>
   inline void Fill(const double value, const double weight, SAMPLES &&samples) {
@@ -248,6 +249,8 @@ Stats operator/(const Stats &, const Stats &);
 Stats Abs(const Stats &);
 Stats Sqrt(const Stats &);
 Stats PowSqrt(const Stats &, unsigned int);
+// fuction for extrapolation RND-sub resolution to full event
+Stats OllitraultExtrapolation( const Stats &, unsigned int );
 }// namespace Qn
 
 #endif//FLOW_STATS_H


### PR DESCRIPTION
Ollitrault extrapolation of rnd-subs first harmonic correlation to full sub. Needed for calculation of rnd-sub method resolution of given harmonic.