### PR TITLE
Issue 26

### DIFF
--- a/include/base/QnTools/Axis.hpp
+++ b/include/base/QnTools/Axis.hpp
@@ -138,7 +138,9 @@ class Axis {
       bin = -1;
     } else {
       auto lb = std::lower_bound(bin_edges_.begin(), bin_edges_.end(), value);
-      if (lb == bin_edges_.begin() || *lb == value)
+      if (lb == bin_edges_.end()) {
+        bin = -1;
+      } else if (lb == bin_edges_.begin() || *lb == value)
         bin = (lb - bin_edges_.begin());
       else
         bin = (lb - bin_edges_.begin()) - 1;


### PR DESCRIPTION
Made test reproducing this issue.
The bug is located in
https://github.com/HeavyIonAnalysis/QnTools/blob/defca4cc9f7876e854f1af5f7c622255dbc4b508/include/base/QnTools/DataContainer.hpp#L600

Qn::Stats object `rebinned.At(...)` is not initialized in the beginning. And it is passed to lambda before initialization.

@mam-mih-val please, run your tests with data

